### PR TITLE
Add the number of confirmations to the transaction model

### DIFF
--- a/src/main/scala/io/stakenet/eth/explorer/models/Transaction.scala
+++ b/src/main/scala/io/stakenet/eth/explorer/models/Transaction.scala
@@ -18,7 +18,8 @@ case class Transaction(
     publicKey: Option[String],
     raw: Option[String],
     timestamp: BigInt,
-    status: Option[TransactionStatus]
+    status: Option[TransactionStatus],
+    confirmations: BigInt
 ) {
 
   // see https://medium.com/swlh/understanding-data-payloads-in-ethereum-transactions-354dbe995371 for more information

--- a/src/main/scala/io/stakenet/eth/explorer/models/transformers/package.scala
+++ b/src/main/scala/io/stakenet/eth/explorer/models/transformers/package.scala
@@ -53,7 +53,8 @@ package object transformers {
       publicKey = Option(transaction.getPublicKey),
       raw = Option(transaction.getRaw),
       timestamp = timestamp,
-      status = status
+      status = status,
+      confirmations = 0
     )
   }
 }

--- a/src/main/scala/io/stakenet/eth/explorer/repository/transactions/TransactionParsers.scala
+++ b/src/main/scala/io/stakenet/eth/explorer/repository/transactions/TransactionParsers.scala
@@ -25,6 +25,7 @@ private[transactions] object TransactionParsers {
     "public_key",
     "raw",
     "timestamp",
-    "status"
+    "status",
+    "confirmations"
   )
 }

--- a/src/main/scala/io/stakenet/eth/explorer/tasks/TransactionStatusSynchronizerTask.scala
+++ b/src/main/scala/io/stakenet/eth/explorer/tasks/TransactionStatusSynchronizerTask.scala
@@ -75,14 +75,16 @@ class TransactionStatusSynchronizerTask @Inject() (
       "public_key",
       "raw",
       "timestamp",
-      "status"
+      "status",
+      "confirmations"
     )
 
     database.withConnection { implicit connection =>
       SQL"""
          SELECT
            t.hash, t.nonce, t.block_hash, t.block_number, t.transaction_index, t.from_address, t.to_address,
-           t.value, t.gas_price, t.gas, t.input, t.creates, t.public_key, t.raw, b.time AS timestamp, t.status
+           t.value, t.gas_price, t.gas, t.input, t.creates, t.public_key, t.raw, b.time AS timestamp, t.status, 
+           (SELECT block_number FROM transactions ORDER BY block_number DESC LIMIT 1) - block_number AS confirmations
          FROM transactions t
          INNER JOIN blocks b USING(block_hash)
          WHERE t.block_number = $number

--- a/src/test/scala/io/stakenet/eth/explorer/Helpers.scala
+++ b/src/test/scala/io/stakenet/eth/explorer/Helpers.scala
@@ -48,7 +48,8 @@ object Helpers {
       publicKey = Some(randomHash()),
       raw = Some(randomHash()),
       timestamp = Random.nextInt(),
-      status = Some(TransactionStatus.Success)
+      status = Some(TransactionStatus.Success),
+      confirmations = 0
     )
   }
 

--- a/src/test/scala/io/stakenet/eth/explorer/services/ETHServiceRPCImplSpec.scala
+++ b/src/test/scala/io/stakenet/eth/explorer/services/ETHServiceRPCImplSpec.scala
@@ -256,7 +256,8 @@ class ETHServiceRPCImplSpec extends AsyncWordSpec with Matchers {
             publicKey = None,
             raw = None,
             timestamp = 1450323467,
-            Some(TransactionStatus.Success)
+            Some(TransactionStatus.Success),
+            confirmations = 0
           )
         )
 


### PR DESCRIPTION
The number of confirmations is calculated with the number of the latest block minus the block number of transaction